### PR TITLE
🔼 Bump version to v0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tressi",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tressi",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "blessed": "^0.1.81",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tressi",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "license": "MIT",
   "author": "kevinchatham",


### PR DESCRIPTION
This PR bumps the package version from v0.0.1 to **v0.0.2** (patch update).

This release fixes a critical bug that prevented the CLI from running load tests correctly. Previously, using the --config option would fail to execute the test and would instead display the help menu. This was caused by improper argument parsing logic in commander.js. The CLI has been refactored to use a default action, ensuring that the load test is now triggered correctly when a configuration file is provided.