### PR TITLE
🔼 Bump version to v0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tressi",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tressi",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "blessed": "^0.1.81",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tressi",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A lightweight, declarative stress testing CLI for modern developers.",
   "license": "MIT",
   "keywords": [

--- a/schemas/tressi.schema.v0.0.9.json
+++ b/schemas/tressi.schema.v0.0.9.json
@@ -1,0 +1,71 @@
+{
+  "$ref": "#/definitions/TressiConfigSchema",
+  "definitions": {
+    "TressiConfigSchema": {
+      "type": "object",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "requests": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "payload": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  {
+                    "type": "array",
+                    "items": {}
+                  }
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "GET",
+                  "POST",
+                  "PUT",
+                  "PATCH",
+                  "DELETE",
+                  "HEAD",
+                  "OPTIONS"
+                ],
+                "default": "GET"
+              },
+              "headers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "requests"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -4,8 +4,8 @@ import ora from 'ora';
 import * as xlsx from 'xlsx';
 
 import { RequestResult } from './stats';
-import { TestSummary } from './summarizer';
 import { getStatusCodeDistributionByCategory } from './stats';
+import { TestSummary } from './summarizer';
 
 async function exportRawLog(
   path: string,
@@ -79,12 +79,17 @@ async function exportXlsx(
 
   // Status Code Distribution Sheet
   const statusCodeMap = runner.getStatusCodeMap();
-  const statusCodeDistribution = getStatusCodeDistributionByCategory(statusCodeMap);
-  const formattedStatusCodeDistribution = Object.entries(statusCodeDistribution).map(([category, count]) => ({
+  const statusCodeDistribution =
+    getStatusCodeDistributionByCategory(statusCodeMap);
+  const formattedStatusCodeDistribution = Object.entries(
+    statusCodeDistribution,
+  ).map(([category, count]) => ({
     'Status Code Category': category,
     Count: count,
   }));
-  const wsStatusCode = xlsx.utils.json_to_sheet(formattedStatusCodeDistribution);
+  const wsStatusCode = xlsx.utils.json_to_sheet(
+    formattedStatusCodeDistribution,
+  );
   xlsx.utils.book_append_sheet(wb, wsStatusCode, 'Status Code Distribution');
 
   const sampledResponses = results.filter((r) => r.body);

--- a/src/index.ts
+++ b/src/index.ts
@@ -403,7 +403,12 @@ export async function runLoadTest(options: RunOptions): Promise<TestSummary> {
       );
       await fs.writeFile(path.join(reportDir, 'report.md'), markdownReport);
 
-      await exportDataFiles(summary, runner.getSampledResults(), reportDir, runner);
+      await exportDataFiles(
+        summary,
+        runner.getSampledResults(),
+        reportDir,
+        runner,
+      );
 
       exportSpinner.succeed(`Successfully exported results to ${reportDir}`);
     } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -403,7 +403,7 @@ export async function runLoadTest(options: RunOptions): Promise<TestSummary> {
       );
       await fs.writeFile(path.join(reportDir, 'report.md'), markdownReport);
 
-      await exportDataFiles(summary, runner.getSampledResults(), reportDir);
+      await exportDataFiles(summary, runner.getSampledResults(), reportDir, runner);
 
       exportSpinner.succeed(`Successfully exported results to ${reportDir}`);
     } catch (err) {

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -310,7 +310,8 @@ export function generateMarkdownReport(
   );
 
   if (Object.keys(statusCodeMap).length > 0) {
-    const statusCodeDistribution = getStatusCodeDistributionByCategory(statusCodeMap);
+    const statusCodeDistribution =
+      getStatusCodeDistributionByCategory(statusCodeMap);
     md += `## Responses by Status Code\n\n`;
     md += `> *A breakdown of all responses by their HTTP status code categories.\n\n`;
     md += `| Status Code Category | Count |\n`;

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -2,6 +2,7 @@ import { TressiConfig } from './config';
 import { RunOptions } from './index';
 import { Runner } from './runner';
 import { RequestResult } from './stats';
+import { getStatusCodeDistributionByCategory } from './stats';
 
 export interface ReportMetadata {
   exportName?: string;
@@ -309,14 +310,13 @@ export function generateMarkdownReport(
   );
 
   if (Object.keys(statusCodeMap).length > 0) {
+    const statusCodeDistribution = getStatusCodeDistributionByCategory(statusCodeMap);
     md += `## Responses by Status Code\n\n`;
-    md += `> *A breakdown of all responses by their HTTP status code.*\n\n`;
-    md += `| Status Code | Count |\n`;
+    md += `> *A breakdown of all responses by their HTTP status code categories.\n\n`;
+    md += `| Status Code Category | Count |\n`;
     md += `|---|---|\n`;
-    for (const [code, count] of Object.entries(statusCodeMap).sort((a, b) =>
-      a[0].localeCompare(b[0]),
-    )) {
-      md += `| ${code} | ${count} |\n`;
+    for (const [category, count] of Object.entries(statusCodeDistribution)) {
+      md += `| ${category} | ${count} |\n`;
     }
     md += `\n`;
   }

--- a/tests/__snapshots__/summarizer.test.ts.snap
+++ b/tests/__snapshots__/summarizer.test.ts.snap
@@ -82,12 +82,15 @@ exports[`summarizer > should generate a comprehensive Markdown report 1`] = `
 
 ## Responses by Status Code
 
-> *A breakdown of all responses by their HTTP status code.*
+> *A breakdown of all responses by their HTTP status code categories.
 
-| Status Code | Count |
+| Status Code Category | Count |
 |---|---|
-| 200 | 3 |
-| 500 | 1 |
+| 2xx | 3 |
+| 3xx | 0 |
+| 4xx | 0 |
+| 5xx | 1 |
+| other | 0 |
 
 ## Endpoint Summary
 

--- a/tests/__snapshots__/summarizer.test.ts.snap
+++ b/tests/__snapshots__/summarizer.test.ts.snap
@@ -5,7 +5,7 @@ exports[`summarizer > should generate a comprehensive Markdown report 1`] = `
 
 | Metric | Value |
 |---|---|
-| Version | 0.0.8 |
+| Version | 0.0.9 |
 | Export Name | my-test-report |
 | Test Time | 12/31/2022, 9:00:00 PM |
 

--- a/tests/circular-buffer.test.ts
+++ b/tests/circular-buffer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { CircularBuffer } from '../src/circular-buffer';
 

--- a/tests/exporter.test.ts
+++ b/tests/exporter.test.ts
@@ -95,6 +95,7 @@ describe('exporter', () => {
   let writeFileMock: Mock;
   let xlsxWriteFileMock: Mock;
   let jsonToSheetMock: Mock;
+  let mockRunner: any;
 
   beforeEach(async () => {
     // Dynamically import the mocked module to get the mock function
@@ -104,6 +105,10 @@ describe('exporter', () => {
     jsonToSheetMock = xlsx.utils.json_to_sheet as Mock;
     writeFileMock.mockClear();
     xlsxWriteFileMock.mockClear();
+
+    mockRunner = {
+      getStatusCodeMap: vi.fn(() => ({ 200: 3, 500: 1 })),
+    };
   });
 
   /**
@@ -111,7 +116,7 @@ describe('exporter', () => {
    * with the correctly formatted data and file paths.
    */
   it('should export all data files and round numbers for reports', async () => {
-    await exportDataFiles(mockSummary, mockResults, './test-output');
+    await exportDataFiles(mockSummary, mockResults, './test-output', mockRunner);
 
     // Should be called 1 time for the raw CSV
     expect(writeFileMock).toHaveBeenCalledTimes(1);
@@ -121,6 +126,7 @@ describe('exporter', () => {
     const bookAppendSheetMock = xlsx.utils.book_append_sheet as Mock;
     const sheetNames = bookAppendSheetMock.mock.calls.map((call) => call[2]);
     expect(sheetNames).toContain('Sampled Responses');
+    expect(sheetNames).toContain('Status Code Distribution');
 
     // Check XLSX call
     expect(xlsxWriteFileMock.mock.calls[0][1]).toBe(
@@ -157,5 +163,15 @@ describe('exporter', () => {
     // 3. Raw Results
     const rawSheetData = jsonToSheetMock.mock.calls[2][0];
     expect(rawSheetData[0].latencyMs).toBe(100); // 100.45 -> 100
+
+    // 4. Status Code Distribution
+    const statusCodeSheetData = jsonToSheetMock.mock.calls[3][0];
+    expect(statusCodeSheetData).toEqual([
+      { 'Status Code Category': '2xx', Count: 3 },
+      { 'Status Code Category': '3xx', Count: 0 },
+      { 'Status Code Category': '4xx', Count: 0 },
+      { 'Status Code Category': '5xx', Count: 1 },
+      { 'Status Code Category': 'other', Count: 0 },
+    ]);
   });
 });

--- a/tests/exporter.test.ts
+++ b/tests/exporter.test.ts
@@ -95,6 +95,7 @@ describe('exporter', () => {
   let writeFileMock: Mock;
   let xlsxWriteFileMock: Mock;
   let jsonToSheetMock: Mock;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockRunner: any;
 
   beforeEach(async () => {
@@ -116,7 +117,12 @@ describe('exporter', () => {
    * with the correctly formatted data and file paths.
    */
   it('should export all data files and round numbers for reports', async () => {
-    await exportDataFiles(mockSummary, mockResults, './test-output', mockRunner);
+    await exportDataFiles(
+      mockSummary,
+      mockResults,
+      './test-output',
+      mockRunner,
+    );
 
     // Should be called 1 time for the raw CSV
     expect(writeFileMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This PR bumps the package version from v0.0.8 to **v0.0.9** (patch update).

feat: Add status code distribution to exported reports

This PR enhances Tressi's reporting capabilities by including a detailed status code distribution in both Markdown and XLSX export formats.

Key changes:

- **XLSX Export:** A new sheet named "Status Code Distribution" has been added to the `report.xlsx` file, providing a breakdown of HTTP status codes by category (2xx, 3xx, 4xx, 5xx, other).
- **Markdown Report:** The `report.md` file now includes a "Responses by Status Code" section that categorizes and counts HTTP responses, offering a clearer overview of test outcomes.
- **Internal Refinements:**
    - The `exportDataFiles` and `exportXlsx` functions were updated to correctly pass and utilize the `runner` object for accessing status code data.
    - Test files (`tests/exporter.test.ts` and `tests/summarizer.test.ts`) and their snapshots were updated to reflect these new reporting features and ensure continued test coverage.
    - Version bumped to 0.0.9.

These improvements provide users with more comprehensive and actionable insights into their load test results, making it easier to identify and diagnose issues related to HTTP response codes.