### PR TITLE
🔼 Bump version to v0.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tressi",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tressi",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "blessed": "^0.1.81",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pretest:spike": "npm run schema:generate",
     "schema:generate": "tsx scripts/generate-schema.ts",
     "start": "npm run build && node dist/cli.js",
-    "test:dev": "tsx src/cli.ts --rps 5 --workers 1 --duration 5 --export",
+    "test:dev": "tsx src/cli.ts --duration 10 --export",
     "test:autoscale": "tsx src/cli.ts --autoscale --workers 50 --rps 1000 --duration 15",
     "test:basic": "tsx src/cli.ts --workers 10 --duration 15 --rps 200",
     "test:ci": "tsx src/cli.ts --workers 5 --duration 15 --rps 300 --no-ui --export",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tressi",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A lightweight, declarative stress testing CLI for modern developers.",
   "license": "MIT",
   "keywords": [

--- a/schemas/tressi.schema.v0.0.11.json
+++ b/schemas/tressi.schema.v0.0.11.json
@@ -1,0 +1,67 @@
+{
+  "$ref": "#/definitions/TressiConfigSchema",
+  "definitions": {
+    "TressiConfigSchema": {
+      "type": "object",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "requests": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "payload": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  {
+                    "type": "array",
+                    "items": {}
+                  }
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "GET",
+                  "POST",
+                  "PUT",
+                  "PATCH",
+                  "DELETE",
+                  "HEAD",
+                  "OPTIONS"
+                ],
+                "default": "GET"
+              },
+              "headers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["url"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["requests"],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -26,6 +26,8 @@ export class Runner extends EventEmitter {
   private recentLatenciesForSpinner: number[] = [];
   private recentRequestTimestamps: CircularBuffer<number>;
   private statusCodeMap: Record<number, number> = {};
+  private successfulRequestsByEndpoint: Map<string, number> = new Map();
+  private failedRequestsByEndpoint: Map<string, number> = new Map();
   private stopped = false;
   private startTime: number = 0;
   private currentTargetRps: number;
@@ -95,8 +97,16 @@ export class Runner extends EventEmitter {
 
     if (result.success) {
       this.successfulRequests++;
+      this.successfulRequestsByEndpoint.set(
+        endpointKey,
+        (this.successfulRequestsByEndpoint.get(endpointKey) || 0) + 1,
+      );
     } else {
       this.failedRequests++;
+      this.failedRequestsByEndpoint.set(
+        endpointKey,
+        (this.failedRequestsByEndpoint.get(endpointKey) || 0) + 1,
+      );
     }
   }
 
@@ -181,6 +191,14 @@ export class Runner extends EventEmitter {
    */
   public getFailedRequestsCount(): number {
     return this.failedRequests;
+  }
+
+  public getSuccessfulRequestsByEndpoint(): Map<string, number> {
+    return this.successfulRequestsByEndpoint;
+  }
+
+  public getFailedRequestsByEndpoint(): Map<string, number> {
+    return this.failedRequestsByEndpoint;
   }
 
   /**

--- a/tests/__snapshots__/summarizer.test.ts.snap
+++ b/tests/__snapshots__/summarizer.test.ts.snap
@@ -5,7 +5,7 @@ exports[`summarizer > should generate a comprehensive Markdown report 1`] = `
 
 | Metric | Value |
 |---|---|
-| Version | 0.0.9 |
+| Version | 0.0.11 |
 | Export Name | my-test-report |
 | Test Time | 12/31/2022, 9:00:00 PM |
 
@@ -74,11 +74,7 @@ exports[`summarizer > should generate a comprehensive Markdown report 1`] = `
 
 ## Error Summary
 
-> *This section summarizes any errors that occurred during the test, grouped by message.*
-
-| Count | Error Message |
-|---|---|
-| 1 | Error |
+> *A total of 1 requests failed. Detailed error messages are available in the raw log (if exported).*
 
 ## Responses by Status Code
 

--- a/tests/summarizer.test.ts
+++ b/tests/summarizer.test.ts
@@ -67,6 +67,18 @@ const mockRunner = {
     [100, 150, 200, 500].forEach((l) => distribution.add(l));
     return distribution;
   },
+  getSuccessfulRequestsByEndpoint: () => {
+    const map = new Map<string, number>();
+    map.set('GET http://a.com', 2);
+    map.set('GET http://b.com', 1);
+    return map;
+  },
+  getFailedRequestsByEndpoint: () => {
+    const map = new Map<string, number>();
+    map.set('GET http://a.com', 0);
+    map.set('GET http://b.com', 1);
+    return map;
+  },
 } as unknown as Runner;
 
 const mockOptions: RunOptions = {

--- a/tressi.config.json
+++ b/tressi.config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./schemas/tressi.schema.v0.0.8.json",
+  "$schema": "./schemas/tressi.schema.v0.0.11.json",
   "headers": {
     "Content-Type": "application/json; charset=UTF-8"
   },


### PR DESCRIPTION
This PR bumps the package version from v0.0.10 to **v0.0.11** (patch update).

fix: Improve reporting accuracy by using total counts

This PR addresses an issue where the terminal summary, Markdown export, and XLSX export were limiting response counts to 1000 due to reliance on sampled results.

**Changes:**

- **`src/runner.ts`**:
    - Introduced new internal tracking for `successfulRequestsByEndpoint` and `failedRequestsByEndpoint` to maintain accurate total counts for each endpoint.
    - Added public methods `getSuccessfulRequestsByEndpoint()` and `getFailedRequestsByEndpoint()` to expose these total counts.
- **`src/summarizer.ts`**:
    - Modified `generateSummary()` to utilize the new total counts from the `Runner` for global and endpoint summaries, ensuring all requests are accounted for.
    - Updated `generateMarkdownReport()`:
        - The "Error Summary" now displays the total number of failed requests, with a note that detailed error messages are available in the raw log (if exported).
        - The "Responses by Status Code" section now uses total counts from `runner.getStatusCodeMap()`.
        - The "Sampled Responses by Endpoint" section continues to use sampled results, as its purpose is to provide example response bodies.
- **`tests/summarizer.test.ts`**:
    - Updated the mock `Runner` to include the newly added methods for endpoint-specific successful and failed request counts.
    - Updated the snapshot to reflect the changes in the Markdown report's error summary.
- **`package.json`, `package-lock.json`, `tressi.config.json`**: Version and schema updates.

These changes ensure that all reports provide accurate, comprehensive statistics without introducing performance bottlenecks, as the `Runner` now efficiently tracks total counts during the test run.