### PR TITLE
fix(workflow): remove invalid `node-auth-token` input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org/'
-          node-auth-token: ${{ secrets.TRESSI_NPM_TOKEN }}
 
       - name: Install dependencies and build
         run: |


### PR DESCRIPTION
- Delete deprecated `node-auth-token` parameter that caused warnings
- Authentication already handled via `NODE_AUTH_TOKEN` env var in npm publish step